### PR TITLE
Potential fix for code scanning alert no. 1: Shell command built from environment values

### DIFF
--- a/index.test.js
+++ b/index.test.js
@@ -19,6 +19,6 @@ test('wait 500 ms', async () => {
 test('test runs', () => {
   process.env['INPUT_MILLISECONDS'] = 100;
   const ip = path.join(__dirname, 'index.js');
-  const result = cp.execSync(`node ${ip}`, {env: process.env}).toString();
+  const result = cp.execFileSync('node', [ip], {env: process.env}).toString();
   console.log(result);
 })


### PR DESCRIPTION
Potential fix for [https://github.com/Abuchtela/a/security/code-scanning/1](https://github.com/Abuchtela/a/security/code-scanning/1)

In general, avoid building a single shell command string that includes environment-derived paths and passing it to `exec`/`execSync`, because that invokes a shell and interprets special characters. Instead, call the executable directly (e.g., `execFile`/`execFileSync` or `spawn`/`spawnSync`) and pass dynamic values as separate arguments so they are not interpreted by a shell.

The best fix here is to replace `cp.execSync(`node ${ip}`, { env: process.env })` with `cp.execFileSync('node', [ip], { env: process.env })`. This preserves the existing behavior of running `node` on the `index.js` file, still using the same environment, but avoids shell parsing entirely and correctly handles any spaces or special characters in `ip`. No other functionality of the test needs to change.

Concretely, in `index.test.js`, in the `test('test runs', ...)` block, update line 22 so that:
- The command is `'node'` (a plain string).
- The arguments are `[ip]`.
- The options object remains `{ env: process.env }`.
- The `.toString()` call stays after `execFileSync` as before.

No new imports or helper methods are required; `child_process` already exports `execFileSync`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test execution infrastructure with no impact to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->